### PR TITLE
增加文字框之例外條件

### DIFF
--- a/MyDrawing/Form1.cs
+++ b/MyDrawing/Form1.cs
@@ -133,7 +133,11 @@ namespace MyDrawing
             // 檢查合法輸入
             try
             {
+                if (comboBoxShapeType.Text == string.Empty)
+                    throw new ArgumentException("請使用下拉選單選擇圖形");
+
                 Shape.Type shapeType = (Shape.Type)Enum.Parse(typeof(Shape.Type), comboBoxShapeType.Text);
+
                 // 內容為空也不被認可
                 if (textBoxShapeContent.Text == string.Empty)
                     throw new ArgumentException($"{nameof(textBoxShapeContent)}.text is empty");
@@ -142,6 +146,10 @@ namespace MyDrawing
                 int width = int.Parse(textBoxShapeWidth.Text);
                 int height = int.Parse(textBoxShapeHeight.Text);
                 model.CreateShape(shapeType, textBoxShapeContent.Text, x, y, width, height);
+            }
+            catch (ArgumentException error)
+            {
+                MessageBox.Show($"警告: {error.Message}");
             }
             catch
             {

--- a/MyDrawing/Form1.cs
+++ b/MyDrawing/Form1.cs
@@ -140,7 +140,8 @@ namespace MyDrawing
 
                 // 內容為空也不被認可
                 if (textBoxShapeContent.Text == string.Empty)
-                    throw new ArgumentException($"{nameof(textBoxShapeContent)}.text is empty");
+                    throw new ArgumentException($"圖形的文字描述框不能為空");
+
                 int x = int.Parse(textBoxShapeX.Text);
                 int y = int.Parse(textBoxShapeY.Text);
                 int width = int.Parse(textBoxShapeWidth.Text);

--- a/MyDrawing/Form1.cs
+++ b/MyDrawing/Form1.cs
@@ -140,7 +140,7 @@ namespace MyDrawing
 
                 // 內容為空也不被認可
                 if (textBoxShapeContent.Text == string.Empty)
-                    throw new ArgumentException($"圖形的文字描述框不能為空");
+                    throw new ArgumentException("圖形的文字描述框不能為空");
 
                 int x = int.Parse(textBoxShapeX.Text);
                 int y = int.Parse(textBoxShapeY.Text);


### PR DESCRIPTION

- 說明: 當你的圖形文字描述框為空的時候，跳出 "警告: 圖形的文字描述框不能為空"，而非原先不明確的文字敘述

![image](https://github.com/user-attachments/assets/f48c81d0-389b-415b-a03f-af33f6781105)
