### PR TITLE
增加圖形資訊之座標與寬高之例外條件

### DIFF
--- a/MyDrawing/Form1.cs
+++ b/MyDrawing/Form1.cs
@@ -133,7 +133,11 @@ namespace MyDrawing
             // 檢查合法輸入
             try
             {
+                if (comboBoxShapeType.Text == string.Empty)
+                    throw new ArgumentException("請使用下拉選單選擇圖形");
+
                 Shape.Type shapeType = (Shape.Type)Enum.Parse(typeof(Shape.Type), comboBoxShapeType.Text);
+
                 // 內容為空也不被認可
                 if (textBoxShapeContent.Text == string.Empty)
                     throw new ArgumentException($"{nameof(textBoxShapeContent)}.text is empty");
@@ -142,6 +146,10 @@ namespace MyDrawing
                 int width = int.Parse(textBoxShapeWidth.Text);
                 int height = int.Parse(textBoxShapeHeight.Text);
                 model.CreateShape(shapeType, textBoxShapeContent.Text, x, y, width, height);
+            }
+            catch (ArgumentException error)
+            {
+                MessageBox.Show($"警告: {error.Message}");
             }
             catch
             {

--- a/MyDrawing/Form1.cs
+++ b/MyDrawing/Form1.cs
@@ -140,7 +140,8 @@ namespace MyDrawing
 
                 // 內容為空也不被認可
                 if (textBoxShapeContent.Text == string.Empty)
-                    throw new ArgumentException($"{nameof(textBoxShapeContent)}.text is empty");
+                    throw new ArgumentException($"圖形的文字描述框不能為空");
+
                 int x = int.Parse(textBoxShapeX.Text);
                 int y = int.Parse(textBoxShapeY.Text);
                 int width = int.Parse(textBoxShapeWidth.Text);

--- a/MyDrawing/Form1.cs
+++ b/MyDrawing/Form1.cs
@@ -142,6 +142,12 @@ namespace MyDrawing
                 if (textBoxShapeContent.Text == string.Empty)
                     throw new ArgumentException("圖形的文字描述框不能為空");
 
+                if (textBoxShapeX.Text == string.Empty ||
+                    textBoxShapeY.Text == string.Empty ||
+                    textBoxShapeWidth.Text == string.Empty ||
+                    textBoxShapeHeight.Text == string.Empty)
+                    throw new ArgumentException("圖形的座標或者寬度高度不能為空");
+
                 int x = int.Parse(textBoxShapeX.Text);
                 int y = int.Parse(textBoxShapeY.Text);
                 int width = int.Parse(textBoxShapeWidth.Text);
@@ -154,7 +160,7 @@ namespace MyDrawing
             }
             catch
             {
-                MessageBox.Show("欄位未輸入或有錯誤");
+                MessageBox.Show("圖形的欄位出現非法輸入");
             }
         }
 

--- a/MyDrawing/Form1.cs
+++ b/MyDrawing/Form1.cs
@@ -140,7 +140,7 @@ namespace MyDrawing
 
                 // 內容為空也不被認可
                 if (textBoxShapeContent.Text == string.Empty)
-                    throw new ArgumentException($"圖形的文字描述框不能為空");
+                    throw new ArgumentException("圖形的文字描述框不能為空");
 
                 int x = int.Parse(textBoxShapeX.Text);
                 int y = int.Parse(textBoxShapeY.Text);


### PR DESCRIPTION
- 說明: 若任一欄位出現空值會丟出錯誤 "圖形的座標或者寬度高度不能為空"，若任一欄位出現非法輸入例如高度輸入 'x' 非整數型別時，丟出 "圖形的欄位出現非法輸入"。

![image](https://github.com/user-attachments/assets/ff1dead6-7a68-4448-8c93-2596bf6efc9a)
